### PR TITLE
add support for package-lock.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# lockfilehook [![npm version](https://badge.fury.io/js/lockfilehook.svg)](https://badge.fury.io/js/lockfilehook)
+# yarnhook [![npm version](https://badge.fury.io/js/yarnhook.svg)](https://badge.fury.io/js/yarnhook)
 
-`lockfilehook` keeps your `node_modules` up-to-date when your `yarn.lock` or `package-lock.json` changes
+`yarnhook` keeps your `node_modules` up-to-date when your `yarn.lock` or `package-lock.json` changes
 due to git operations like `checkout`, `merge`, `rebase`, `pull` etc.
 
 # Installation
@@ -8,33 +8,33 @@ due to git operations like `checkout`, `merge`, `rebase`, `pull` etc.
 This package should be used with [husky](https://www.npmjs.com/package/husky).
 
 ```sh
-yarn add --dev lockfilehook husky
+yarn add --dev yarnhook husky
 # or 
-npm install --save-dev lockfilehook husky
+npm install --save-dev yarnhook husky
 ```
 
 # Usage
 
-You should let `lockfilehook` handle git hooks that change the dependencies. Example
+You should let `yarnhook` handle git hooks that change the dependencies. Example
 `package.json` is as follows:
 
 ```json
 {
   "scripts": {
-    "postmerge": "lockfilehook",
-    "postcheckout": "lockfilehook",
-    "postrewrite": "lockfilehook"
+    "postmerge": "yarnhook",
+    "postcheckout": "yarnhook",
+    "postrewrite": "yarnhook"
   }
 }
 ```
 
 # Flags
 
-Prepend `LOCKFILEHOOK_BYPASS=true` to your git command if you don't want to run
-`[yarn|npm] install` as a result, `LOCKFILEHOOK_DEBUG=true` to print debug information.
+Prepend `YARNHOOK_BYPASS=true` to your git command if you don't want to run
+`yarn install` or `npm install` as a result, `YARNHOOK_DEBUG=true` to print debug information.
 
 An example:
 
 ```sh
-LOCKFILEHOOK_BYPASS=true git checkout feature-branch
+YARNHOOK_BYPASS=true git checkout feature-branch
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# yarnhook [![npm version](https://badge.fury.io/js/yarnhook.svg)](https://badge.fury.io/js/yarnhook)
+# lockfilehook [![npm version](https://badge.fury.io/js/lockfilehook.svg)](https://badge.fury.io/js/lockfilehook)
 
-`yarnhook` keeps your `node_modules` up-to-date when your `yarn.lock` changes
+`lockfilehook` keeps your `node_modules` up-to-date when your `yarn.lock` or `package-lock.json` changes
 due to git operations like `checkout`, `merge`, `rebase`, `pull` etc.
 
 # Installation
@@ -8,31 +8,33 @@ due to git operations like `checkout`, `merge`, `rebase`, `pull` etc.
 This package should be used with [husky](https://www.npmjs.com/package/husky).
 
 ```sh
-yarn add --dev yarnhook husky
+yarn add --dev lockfilehook husky
+# or 
+npm install --save-dev lockfilehook husky
 ```
 
 # Usage
 
-You should let `yarnhook` handle git hooks that change the dependencies. Example
+You should let `lockfilehook` handle git hooks that change the dependencies. Example
 `package.json` is as follows:
 
 ```json
 {
   "scripts": {
-    "postmerge": "yarnhook",
-    "postcheckout": "yarnhook",
-    "postrewrite": "yarnhook"
+    "postmerge": "lockfilehook",
+    "postcheckout": "lockfilehook",
+    "postrewrite": "lockfilehook"
   }
 }
 ```
 
 # Flags
 
-Prepend `YARNHOOK_BYPASS=true` to your git command if you don't want to run
-`yarn install` as a result, `YARNHOOK_DEBUG=true` to print debug information.
+Prepend `LOCKFILEHOOK_BYPASS=true` to your git command if you don't want to run
+`[yarn|npm] install` as a result, `LOCKFILEHOOK_DEBUG=true` to print debug information.
 
 An example:
 
 ```sh
-YARNHOOK_BYPASS=true git checkout feature-branch
+LOCKFILEHOOK_BYPASS=true git checkout feature-branch
 ```

--- a/index.js
+++ b/index.js
@@ -5,32 +5,58 @@
 const findParentDir = require("find-parent-dir");
 const { execSync } = require("child_process");
 const { join } = require("path");
+const fs = require('fs');
 
-const { YARNHOOK_BYPASS = false, YARNHOOK_DEBUG = false } = process.env;
+const { LOCKFILEHOOK_BYPASS = false, LOCKFILEHOOK_DEBUG = false } = process.env;
 
-if (!YARNHOOK_BYPASS) {
+if (!LOCKFILEHOOK_BYPASS) {
   // switch to gitdir
   const currentDir = process.cwd();
   const gitDir = findParentDir.sync(currentDir, ".git");
+  const yarnLockPath = join(currentDir, "yarn.lock");
+  const npmLockPath = join(currentDir, "package-lock.json");
 
-  if (YARNHOOK_DEBUG) {
-    console.log(currentDir, gitDir);
+  // check for yarn's and npm's lockfiles
+  let CMD = "";
+  const getLockfile = function() {
+    // get yarn's lockfile
+    if (fs.existsSync(yarnLockPath)) {
+      CMD = "yarn";
+      return yarnLockPath;
+    }
+
+    // get npm's lockfile
+    if (fs.existsSync(npmLockPath)) {
+      CMD = "npm";
+      return npmLockPath;
+    }
+
+    return null;
   }
 
-  // run git diff HEAD@{1}..HEAD@{0} -- $CWD/yarn.lock
-  const yarnLockPath = join(currentDir, "yarn.lock");
-  const output = execSync(`git diff HEAD@{1}..HEAD@{0} -- ${yarnLockPath}`, {
+  const lockfile = getLockfile();
+
+  if (LOCKFILEHOOK_DEBUG) {
+    console.log('currentDir:', currentDir);
+    console.log('gitDir:', gitDir);
+    console.log('lockfile:', lockfile);
+    console.log('CMD:', CMD);
+  }
+
+  // run a git diff on the lockfile
+  const output = execSync(`git diff HEAD@{1}..HEAD@{0} -- ${lockfile}`, {
     cwd: gitDir,
     encoding: "utf-8"
   });
 
-  if (YARNHOOK_DEBUG) {
-    console.log(output);
+  if (LOCKFILEHOOK_DEBUG) {
+    console.log(output, output.length > 0);
   }
 
-  // if diff exists, run yarn install
+  // if diff exists, update dependencies
   if (output.length > 0) {
-    const output = execSync("yarn install", { encoding: "utf-8" });
+    console.log(`Changes to lockfile found, running \`${CMD} install\``);
+    const output = execSync(`${CMD} install`, { encoding: "utf-8" });
     console.log(output);
   }
 }

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@
 const findParentDir = require("find-parent-dir");
 const { execSync } = require("child_process");
 const { join } = require("path");
-const fs = require('fs');
+const fs = require("fs");
 
 const { LOCKFILEHOOK_BYPASS = false, LOCKFILEHOOK_DEBUG = false } = process.env;
 
@@ -32,15 +32,15 @@ if (!LOCKFILEHOOK_BYPASS) {
     }
 
     return null;
-  }
+  };
 
   const lockfile = getLockfile();
 
   if (LOCKFILEHOOK_DEBUG) {
-    console.log('currentDir:', currentDir);
-    console.log('gitDir:', gitDir);
-    console.log('lockfile:', lockfile);
-    console.log('CMD:', CMD);
+    console.log("currentDir:", currentDir);
+    console.log("gitDir:", gitDir);
+    console.log("lockfile:", lockfile);
+    console.log("CMD:", CMD);
   }
 
   // run a git diff on the lockfile

--- a/index.js
+++ b/index.js
@@ -43,20 +43,28 @@ if (!YARNHOOK_BYPASS) {
     console.log("CMD:", CMD);
   }
 
-  // run a git diff on the lockfile
-  const output = execSync(`git diff HEAD@{1}..HEAD@{0} -- ${lockfile}`, {
-    cwd: gitDir,
-    encoding: "utf-8"
-  });
+  if (lockfile !== null) {
+    // run a git diff on the lockfile
+    const output = execSync(`git diff HEAD@{1}..HEAD@{0} -- ${lockfile}`, {
+      cwd: gitDir,
+      encoding: "utf-8"
+    });
 
-  if (YARNHOOK_DEBUG) {
-    console.log(output, output.length > 0);
-  }
+    if (YARNHOOK_DEBUG) {
+      console.log(output, output.length > 0);
+    }
 
-  // if diff exists, update dependencies
-  if (output.length > 0) {
-    console.log(`Changes to lockfile found, running \`${CMD} install\``);
-    const output = execSync(`${CMD} install`, { encoding: "utf-8" });
-    console.log(output);
+    // if diff exists, update dependencies
+    if (output.length > 0) {
+      console.log(`Changes to lockfile found, running \`${CMD} install\``);
+      const output = execSync(`${CMD} install`, { encoding: "utf-8" });
+      console.log(output);
+    }
+  } else {
+    console.log(
+      "I can't seem to find either yarn.lock or package-lock.json. Please " +
+        "open an issue at https://github.com/frontsideair/yarnhook/issues if " +
+        "you think it's my fault."
+    );
   }
 }

--- a/index.js
+++ b/index.js
@@ -7,9 +7,9 @@ const { execSync } = require("child_process");
 const { join } = require("path");
 const fs = require("fs");
 
-const { LOCKFILEHOOK_BYPASS = false, LOCKFILEHOOK_DEBUG = false } = process.env;
+const { YARNHOOK_BYPASS = false, YARNHOOK_DEBUG = false } = process.env;
 
-if (!LOCKFILEHOOK_BYPASS) {
+if (!YARNHOOK_BYPASS) {
   // switch to gitdir
   const currentDir = process.cwd();
   const gitDir = findParentDir.sync(currentDir, ".git");
@@ -36,7 +36,7 @@ if (!LOCKFILEHOOK_BYPASS) {
 
   const lockfile = getLockfile();
 
-  if (LOCKFILEHOOK_DEBUG) {
+  if (YARNHOOK_DEBUG) {
     console.log("currentDir:", currentDir);
     console.log("gitDir:", gitDir);
     console.log("lockfile:", lockfile);
@@ -49,7 +49,7 @@ if (!LOCKFILEHOOK_BYPASS) {
     encoding: "utf-8"
   });
 
-  if (LOCKFILEHOOK_DEBUG) {
+  if (YARNHOOK_DEBUG) {
     console.log(output, output.length > 0);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "lockfilehook",
+  "name": "yarnhook",
   "version": "0.0.2",
   "bin": "index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yarnhook",
+  "name": "lockfilehook",
   "version": "0.0.2",
   "bin": "index.js",
   "files": [


### PR DESCRIPTION
Hi, thanks for the useful package! I added support for repos that use `npm` instead of `yarn`. I would have created an issue first, but you have that disabled... so feel free to reject this PR!

~Also, this kind of makes the package name obsolete so I changed it to a more general `lockfilehook`.~
