### PR TITLE
Stream yarn/npm output

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 // @flow
 
 const findParentDir = require("find-parent-dir");
-const { execSync } = require("child_process");
+const execa = require("execa");
 const { join } = require("path");
 const fs = require("fs");
 
@@ -43,12 +43,13 @@ if (!YARNHOOK_BYPASS) {
     console.log("CMD:", CMD);
   }
 
-  if (lockfile !== null) {
+  if (lockfile) {
     // run a git diff on the lockfile
-    const output = execSync(`git diff HEAD@{1}..HEAD@{0} -- ${lockfile}`, {
-      cwd: gitDir,
-      encoding: "utf-8"
-    });
+    const { stdout: output } = execa.sync(
+      "git",
+      ["diff", "HEAD@{1}..HEAD@{0}", "--", lockfile],
+      { cwd: gitDir }
+    );
 
     if (YARNHOOK_DEBUG) {
       console.log(output, output.length > 0);
@@ -57,8 +58,7 @@ if (!YARNHOOK_BYPASS) {
     // if diff exists, update dependencies
     if (output.length > 0) {
       console.log(`Changes to lockfile found, running \`${CMD} install\``);
-      const output = execSync(`${CMD} install`, { encoding: "utf-8" });
-      console.log(output);
+      execa.sync(CMD, ["install"], { stdio: "inherit" });
     }
   } else {
     console.log(

--- a/index.js
+++ b/index.js
@@ -43,13 +43,11 @@ if (!YARNHOOK_BYPASS) {
     console.log("CMD:", CMD);
   }
 
-  if (lockfile) {
+  if (lockfile !== null) {
     // run a git diff on the lockfile
-    const { stdout: output } = execa.sync(
-      "git",
-      ["diff", "HEAD@{1}..HEAD@{0}", "--", lockfile],
-      { cwd: gitDir }
-    );
+    const { stdout: output } = execa.sync("git", ["diff", "HEAD@{1}..HEAD@{0}", "--", lockfile], {
+      cwd: gitDir
+    });
 
     if (YARNHOOK_DEBUG) {
       console.log(output, output.length > 0);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "author": "Fatih Altinok <photonia@gmail.com>",
   "license": "MIT",
   "dependencies": {
+    "execa": "^0.8.0",
     "find-parent-dir": "^0.3.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,26 @@
 # yarn lockfile v1
 
 
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
+execa@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 find-parent-dir@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
@@ -10,6 +30,71 @@ flow-bin@^0.61.0:
   version "0.61.0"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.61.0.tgz#d0473a8c35dbbf4de573823f4932124397d32d35"
 
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
+is-stream@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
+
+lru-cache@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+
+path-key@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
+
 prettier@^1.9.2:
   version "1.9.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.9.2.tgz#96bc2132f7a32338e6078aeb29727178c6335827"
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
+
+signal-exit@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+
+which@^1.2.9:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  dependencies:
+    isexe "^2.0.0"
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"


### PR DESCRIPTION
This adds yarn/npm output streaming so that you can see the real time install output / progress bar. This also makes it so that the yarn/npm output colors are maintained. I also [added execa for these reasons](https://github.com/sindresorhus/execa#why).

PS: you should remove prettier from the devDependencies since it's misleading.