### PR TITLE
Fix for lerna/monorepos: always run from git root 

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ if (!YARNHOOK_BYPASS) {
       } else {
         console.log(`Changes to lockfile found, running \`${cmd} install\``);
         try {
-          execa.sync(cmd, args[cmd], { stdio: "inherit" });
+          execa.sync(cmd, args[cmd], { stdio: "inherit", cwd: gitDir });
         } catch (err) {
           console.warn(`Running ${cmd} ${args[cmd].join(' ')} failed`);
         }


### PR DESCRIPTION
Typical lerna repo:

```
package.json
packages/
  - package1/
      - package.json
```

I have this in my root `package.json`:

```
  "scripts": {
    "postinstall": "lerna bootstrap",
  }
```

running `git checkout` from inside `package1` will result in installing dependencies only for this package and will remove symlinks to other dependencies inside the monorepo

This fix always run the install from the root, then via the postinstall script runs `lerna boostrap` and install dependencies in sub packages