### PR TITLE
Use `npm install` with `--no-save` to prevent lockfile changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const lockfileSpecs = [
 
 const args = {
   yarn: ["install", "--prefer-offline", "--pure-lockfile"],
-  npm: ["install", "--prefer-offline", "--no-audit"],
+  npm: ["install", "--prefer-offline", "--no-audit", "--no-save"],
   pnpm: ["install", "--prefer-offline", "--prefer-frozen-shrinkwrap"]
 };
 


### PR DESCRIPTION
>  Using a locked package is no different than using any package without a package lock: any commands that update node_modules and/or package.json’s dependencies will automatically sync the existing lockfile. This includes npm install, npm rm, npm update, etc. To prevent this update from happening, you can use the --no-save option to prevent saving altogether [...]

https://docs.npmjs.com/files/package-locks#using-locked-packages