### PR TITLE
Updates find-parent-dir package in yarnhook

### DIFF
--- a/packages/yarnhook/package.json
+++ b/packages/yarnhook/package.json
@@ -23,6 +23,6 @@
   },
   "dependencies": {
     "execa": "^4.0.3",
-    "find-parent-dir": "^0.3.0"
+    "find-parent-dir": "^0.3.1"
   }
 }

--- a/packages/yarnhook/yarn.lock
+++ b/packages/yarnhook/yarn.lock
@@ -33,10 +33,10 @@ execa@^4.0.3:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
-find-parent-dir@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
-  integrity sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=
+find-parent-dir@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.1.tgz#c5c385b96858c3351f95d446cab866cbf9f11125"
+  integrity sha512-o4UcykWV/XN9wm+jMEtWLPlV8RXCZnMhQI6F6OdHeSez7iiJWePw8ijOlskJZMsaQoGR/b7dH6lO02HhaTN7+A==
 
 get-stream@^5.0.0:
   version "5.2.0"


### PR DESCRIPTION
find-parent-dir
  * yarnhook: ^0.3.0 → 0.3.1

Fixes `DeprecationWarning: Invalid 'main' field` warnings, which was fixed here https://github.com/thlorenz/find-parent-dir/commit/755a3ab76703517762093dc8a5af83a0a93c9645

